### PR TITLE
Add sample PR template

### DIFF
--- a/pr_templates/sample_backend_pr_template.md
+++ b/pr_templates/sample_backend_pr_template.md
@@ -1,0 +1,25 @@
+#### Task: [JiraTaskNumber](https://htdevelopers.atlassian.net/browse/JiraTaskNumber)
+
+[Brief single sentence description of the changes.]
+
+Changes:
+* One
+* Two
+* Three
+
+#### Dev checklist:
+* [ ] Unit specs updated
+* [ ] Request specs updated
+* [ ] Postman updated
+
+#### QA checklist:
+* [ ] **Tested on Web**
+* [ ] **Tested on Mobile**
+
+#### Test Cases
+- OPTIONAL INFORMATION THAT CAN BE HELPFUL FOR QA
+
+#### Design
+[See design](figma/invision link here)
+
+Screenshots/Gifs:

--- a/pr_templates/sample_mobile_pr_template.md
+++ b/pr_templates/sample_mobile_pr_template.md
@@ -10,22 +10,19 @@ Changes:
 * Two
 * Three
 
-#### Tests:
+#### Dev checklist
+* [ ] Jest tests updated
+* [ ] E2E tests updated
 
-* [ ] Tests updated
-* [ ] Tests went green
+#### QA checklist:
+* [ ] **Tested on Android**
+* [ ] **Tested on Old iPhones**
+* [ ] **Tested on iPhones X**
 
-#### API Checklist:
-
-* [ ] Postman updated
-
-#### REACT NATIVE Checklist:
-
-* [ ] Tested on Android
-* [ ] Tested on iOS
+#### Test Cases
+- OPTIONAL INFORMATION THAT CAN BE HELPFUL FOR QA
 
 #### Design
-
 [See design](figma/invision link here)
 
 Screenshots/Gifs:

--- a/pr_templates/sample_web_pr_template.md
+++ b/pr_templates/sample_web_pr_template.md
@@ -1,0 +1,30 @@
+#### Task: [JiraTaskNumber](https://htdevelopers.atlassian.net/browse/JiraTaskNumber)
+
+Commons PR:
+- [ ] [CommonsNumber](https://github.com/htdevelopers/nutrimedy-commons/pull/CommonsNumber)
+
+[Brief single sentence description of the changes.]
+
+Changes:
+* One
+* Two
+* Three
+
+#### Dev checklist:
+* [ ] Jest tests updated
+* [ ] E2E tests updated
+
+#### QA checklist:
+* [ ] **Tested on Chrome**
+* [ ] **Tested on Safari**
+* [ ] **Tested on Firefox**
+* [ ] **Tested on Edge**
+* [ ] **Tested on IE**
+
+#### Test Cases
+- OPTIONAL INFORMATION THAT CAN BE HELPFUL FOR QA
+
+#### Design
+[See design](figma/invision link here)
+
+Screenshots/Gifs:

--- a/sources/sample_pr_template.md
+++ b/sources/sample_pr_template.md
@@ -1,0 +1,31 @@
+#### Task: [JiraTaskNumber](https://htdevelopers.atlassian.net/browse/JiraTaskNumber)
+
+Commons PR:
+- [ ] [CommonsNumber](https://github.com/htdevelopers/nutrimedy-commons/pull/CommonsNumber)
+
+[Brief single sentence description of the changes.]
+
+Changes:
+* One
+* Two
+* Three
+
+#### Tests:
+
+* [ ] Tests updated
+* [ ] Tests went green
+
+#### API Checklist:
+
+* [ ] Postman updated
+
+#### REACT NATIVE Checklist:
+
+* [ ] Tested on Android
+* [ ] Tested on iOS
+
+#### Design
+
+[See design](figma/invision link here)
+
+Screenshots/Gifs:

--- a/workflow-guideline.md
+++ b/workflow-guideline.md
@@ -6,7 +6,7 @@ Remember to include the general change log in the Pull Request description. It w
 
 ### Things considered a good practice when working with Pull Requests:
 - Stick to the naming convention that the team agreed on e.g. `feature/nut-123-style-appointment-screen/`
-- Respect the template for opening new Pull Requests if one is provided. Otherwise it is the best time to create one, you can find sample [here](https://github.com/HealthTechDevelopers/playbook/blob/master/sources/sample_pr_template.md) and adjust it to your needs.
+- Respect the template for opening new Pull Requests if one is provided. Otherwise it is the best time to [create one](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository), you can find samples [here](https://github.com/HealthTechDevelopers/playbook/blob/master/pr_templates/) and adjust it to your needs.
 - Make sure that your Pull Request is in fact ready and could be merged to master branch as is. Don’t force others to waste their time on finding typos or silly mistakes
 - It is acceptable to use ‚work in progress’ Pull Requests to satisfy different needs during development process. In that case attach the `WIP` signature to the title or use GitHub's **Draft Pull Request** feature and do not ask for review until the Pull Request is good to go
 - Feel free to friendly remind your teammates of a pending Code Review

--- a/workflow-guideline.md
+++ b/workflow-guideline.md
@@ -6,7 +6,7 @@ Remember to include the general change log in the Pull Request description. It w
 
 ### Things considered a good practice when working with Pull Requests:
 - Stick to the naming convention that the team agreed on e.g. `feature/nut-123-style-appointment-screen/`
-- Respect the template for opening new Pull Requests if one is provided. Otherwise it is the best time to create one
+- Respect the template for opening new Pull Requests if one is provided. Otherwise it is the best time to create one, you can find sample [here](https://github.com/HealthTechDevelopers/playbook/blob/master/sources/sample_pr_template.md) and adjust it to your needs.
 - Make sure that your Pull Request is in fact ready and could be merged to master branch as is. Don’t force others to waste their time on finding typos or silly mistakes
 - It is acceptable to use ‚work in progress’ Pull Requests to satisfy different needs during development process. In that case attach the `WIP` signature to the title or use GitHub's **Draft Pull Request** feature and do not ask for review until the Pull Request is good to go
 - Feel free to friendly remind your teammates of a pending Code Review


### PR DESCRIPTION
I think this is a good sample PR template (consists of a couple mixed together from Nu).
Of course, parts like commons, RN, API, Design and screenshots can be removed according to each PR needs. It will be nice to remove/add things that you guys find useful in your templates. Let's discuss it here.

Related to: https://github.com/HealthTechDevelopers/playbook/issues/33